### PR TITLE
Fix german translation of chapel bonus

### DIFF
--- a/i18n/Messages_de.properties
+++ b/i18n/Messages_de.properties
@@ -149,7 +149,7 @@ CH03.name=Gruft
 CH03.bonus=Die Summe der Basisstärken aller <span class="undead">Untoten</span>.
 CH03.penalty=BLOCKIERT alle <span class="leader">Anführer</span>.
 CH04.name=Kapelle
-CH04.bonus=+40 wenn Du insgesamt genau zwei Karten der folgenden Farben hast: <span class="leader">Anführer</span>, <span class="wizard">Zaubrer</span>, <span class="outsider">Outsider</span> und <span class="Untote">Undead</span>.
+CH04.bonus=+40 wenn Du insgesamt genau zwei Karten der folgenden Farben hast: <span class="leader">Anführer</span>, <span class="wizard">Zauberer</span>, <span class="outsider">Outsider</span> und <span class="undead">Untote</span>.
 CH05.name=Garten
 CH05.bonus=+11 für jeden <span class="leader">Anführer</span> und/oder <span class="beast">Bestie</span>.
 CH05.penalty=Ist BLOCKIERT, wenn zusammen mit <span class="undead">Untote</span>, <span class="wizard">Totenbeschwörer</span> und/oder <span class="outsider">Dämon</span>.


### PR DESCRIPTION
Hey, there is a typo and mixup of css class name and suit name in the German translation of the Chapel's bonus.