### PR TITLE
Fix typo in German translation

### DIFF
--- a/i18n/Messages_de.properties
+++ b/i18n/Messages_de.properties
@@ -131,10 +131,10 @@ FR49.action=Wähle eine Farbe und eine Zielkarte aus deiner Hand.
 FR50.name=Rune des Schutzes
 FR50.bonus=HEBT die Strafen auf allen Karten AUF.
 FR51.name=Gestaltwandler
-FR51.bonus=Kann Namen uns Farbe eines beliebigen <span class="artifact">Artefakts</span>, <span class="leader">Anführers</span>, <span class="wizard">Zauberers</span>, <span class="weapon">Waffe</span> oder <span class="beast">Bestie</span> des Spiels kopieren. <br />Übernimmt nicht Bonus, Strafen oder Basisstärke der entsprechenden Karte.
+FR51.bonus=Kann Namen und Farbe eines beliebigen <span class="artifact">Artefakts</span>, <span class="leader">Anführers</span>, <span class="wizard">Zauberers</span>, <span class="weapon">Waffe</span> oder <span class="beast">Bestie</span> des Spiels kopieren. <br />Übernimmt nicht Bonus, Strafen oder Basisstärke der entsprechenden Karte.
 FR51.action=Wähle eine Zielkarte zum Duplizieren aus.
 FR52.name=Spiegelung
-FR52.bonus=Kann Namen uns Farbe einer beliebigen <span class="army">Armee</span>, <span class="land">Land</span>, <span class="weather">Wetter</span>, <span class="flood">Flut</span> oder <span class="flame">Flamme</span> im Spiel kopieren. <br />Übernimmt nicht Bonus, Strafen oder Basisstärke der entsprechenden Karte.
+FR52.bonus=Kann Namen und Farbe einer beliebigen <span class="army">Armee</span>, <span class="land">Land</span>, <span class="weather">Wetter</span>, <span class="flood">Flut</span> oder <span class="flame">Flamme</span> im Spiel kopieren. <br />Übernimmt nicht Bonus, Strafen oder Basisstärke der entsprechenden Karte.
 FR52.action=Wähle eine Zielkarte zum Duplizieren aus.
 FR53.name=Doppelgänger
 FR53.bonus=Kann Namen, Basisstärke, Farbe und Strafe ABER NICHT DEN BONUS einer anderen Karte in Deiner Hand kopieren.


### PR DESCRIPTION
"uns" means "ours", but in this context, "und" ("and") is meant.