### PR TITLE
Add Phoenix (Deluxe Edition)

### DIFF
--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -142,7 +142,8 @@ FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
 FR55.name=Phoenix
-FR55.penalty=BLANKED by any <span class="flood">Flood</span>
+FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card.
+FR55.penalty=BLANKED with any <span class="flood">Flood</span>.
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.
 CH02.name=Castle

--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -142,7 +142,7 @@ FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
 FR55.name=Phoenix
-FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card.
+FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card. <br /><b>Phoenix</b> is immune to the <b>Book of Changes</b> and may not BLANK or be BLANKED by any other card.
 FR55.penalty=BLANKED with any <span class="flood">Flood</span>.
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.

--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -141,6 +141,8 @@ FR53.bonus=<b>Doppelgänger</b> may duplicate the name, base strength, suit, and
 FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
+FR55.name=Phoenix
+FR55.penalty=BLANKED by any <span class="flood">Flood</span>
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.
 CH02.name=Castle

--- a/i18n/Messages_en.properties
+++ b/i18n/Messages_en.properties
@@ -142,7 +142,8 @@ FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
 FR55.name=Phoenix
-FR55.penalty=BLANKED by any <span class="flood">Flood</span>
+FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card.
+FR55.penalty=BLANKED with any <span class="flood">Flood</span>.
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.
 CH02.name=Castle

--- a/i18n/Messages_en.properties
+++ b/i18n/Messages_en.properties
@@ -142,7 +142,7 @@ FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
 FR55.name=Phoenix
-FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card.
+FR55.bonus=Also counts as a <span class="flame">Flame</span> and <span class="weather">Weather</span> card. <br /><b>Phoenix</b> is immune to the <b>Book of Changes</b> and may not BLANK or be BLANKED by any other card.
 FR55.penalty=BLANKED with any <span class="flood">Flood</span>.
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.

--- a/i18n/Messages_en.properties
+++ b/i18n/Messages_en.properties
@@ -141,6 +141,8 @@ FR53.bonus=<b>Doppelgänger</b> may duplicate the name, base strength, suit, and
 FR53.action=Pick a card from your hand to duplicate.
 FR54.name=Jester
 FR54.bonus=+3 for each other card with an odd base value. <br />OR +50 if entire hand has odd base values.
+FR55.name=Phoenix
+FR55.penalty=BLANKED by any <span class="flood">Flood</span>
 CH01.name=Dungeon
 CH01.bonus=+10 each for the first <span class="undead">Undead</span>, <span class="beast">Beast</span>, and <span class="artifact">Artifact</span>. <br />+5 for each additional card in any of these suits and <span class="wizard">Necromancer</span>, <span class="wizard">Warlock Lord</span>, <span class="outsider">Demon</span>.
 CH02.name=Castle

--- a/js/app.js
+++ b/js/app.js
@@ -218,7 +218,7 @@ function selectFromHand(id) {
   if (card.cursedItem) {
     removeFromHand(id);
   } else if (actionId === BOOK_OF_CHANGES) {
-    if (id !== BOOK_OF_CHANGES) {
+    if (id !== BOOK_OF_CHANGES && id !== PHOENIX) {
       click.play();
       bookOfChangesSelectedCard = id;
       performBookOfChanges();

--- a/js/app.js
+++ b/js/app.js
@@ -235,7 +235,7 @@ function selectFromHand(id) {
   } else if (actionId === ISLAND) {
     var selectedCard = hand.getCardById(id);
     var island = hand.getCardById(ISLAND);
-    if (selectedCard.suit === 'flood' || selectedCard.suit === 'flame') {
+    if (selectedCard.suit === 'flood' || selectedCard.suit === 'flame' || selectedCard.id === PHOENIX) {
       actionId = NONE;
       click.play();
       magic.play();

--- a/js/deck.js
+++ b/js/deck.js
@@ -217,7 +217,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 15 * (hand.countSuitExcluding('weather', this.id)) + hand.containsId(PHOENIX, false) ? 15 : 0;
+      return 15 * (hand.countSuitExcluding('weather', this.id)) + (hand.containsId(PHOENIX, false) ? 15 : 0);
     },
     relatedSuits: ['weather'],
     relatedCards: []
@@ -285,7 +285,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 15 * (hand.countSuitExcluding('flame', this.id)) + hand.containsId(PHOENIX, false) ? 15 : 0;
+      return 15 * (hand.countSuitExcluding('flame', this.id)) + (hand.containsId(PHOENIX, false) ? 15 : 0);
     },
     relatedSuits: ['flame'],
     relatedCards: []
@@ -827,7 +827,7 @@ var base = {
     suit: 'beast',
     name: 'Phoenix',
     strength: 14,
-    bonus: false,
+    bonus: true,
     penalty: true,
     blankedIf: function(hand) {
       return hand.containsSuit('flood');

--- a/js/deck.js
+++ b/js/deck.js
@@ -99,7 +99,7 @@ var base = {
     bonus: false,
     penalty: true,
     penaltyScore: function(hand) {
-      var penaltyCards = hand.countSuit('flame') + hand.containsId(PHOENIX, false) ? 1 : 0;
+      var penaltyCards = hand.countSuit('flame');
       if (!isArmyClearedFromPenalty(this, hand)) {
         penaltyCards += hand.countSuit('army');
       }
@@ -191,7 +191,7 @@ var base = {
     bonus: false,
     penalty: true,
     blankedIf: function(hand) {
-      return !hand.containsSuit('flame') && !hand.containsId(PHOENIX, false);
+      return !hand.containsSuit('flame');
     },
     relatedSuits: ['flame'],
     relatedCards: []
@@ -217,7 +217,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 15 * (hand.countSuitExcluding('weather', this.id)) + (hand.containsId(PHOENIX, false) ? 15 : 0);
+      return 15 * hand.countSuitExcluding('weather', this.id);
     },
     relatedSuits: ['weather'],
     relatedCards: []
@@ -285,7 +285,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 15 * (hand.countSuitExcluding('flame', this.id)) + (hand.containsId(PHOENIX, false) ? 15 : 0);
+      return 15 * hand.countSuitExcluding('flame', this.id);
     },
     relatedSuits: ['flame'],
     relatedCards: []
@@ -311,7 +311,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return hand.containsSuit('weather') || hand.containsId(PHOENIX, false) ? 0 : 5;
+      return hand.containsSuit('weather') ? 0 : 5;
     },
     relatedSuits: ['weather'],
     relatedCards: []
@@ -449,8 +449,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 5 * (hand.countSuit('land') + hand.countSuit('weather') + hand.countSuit('flood') + hand.countSuit('flame'))
-        + hand.containsId(PHOENIX, false) ? 5 : 0;
+      return 5 * (hand.countSuit('land') + hand.countSuit('weather') + hand.countSuit('flood') + hand.countSuit('flame'));
     },
     relatedSuits: ['land', 'weather', 'flood', 'flame'],
     relatedCards: []
@@ -656,7 +655,7 @@ var base = {
     bonus: false,
     penalty: true,
     blankedIf: function(hand) {
-      return (!hand.containsSuit('army') && !isArmyClearedFromPenalty(this, hand)) || hand.containsSuit('weather');
+      return (!hand.containsSuit('army') && !isArmyClearedFromPenalty(this, hand)) || hand.containsSuitExcluding('weather', PHOENIX);
     },
     relatedSuits: ['army', 'weather'],
     relatedCards: []
@@ -991,7 +990,7 @@ var cursedHoard = {
     bonus: false,
     penalty: true,
     blanks: function(card, hand) {
-      return card.suit !== 'outsider' && hand.countSuitWithPhoenix(card.suit) === 1 && card.id !== PHOENIX;
+      return card.suit !== 'outsider' && hand.countSuit(card.suit) === 1 && card.id !== PHOENIX;
     },
     relatedSuits: ['outsider'],
     relatedCards: []

--- a/js/deck.js
+++ b/js/deck.js
@@ -26,7 +26,7 @@ var base = {
       return hand.contains('Dwarvish Infantry') || hand.contains('Dragon') ? 25 : 0;
     },
     clearsPenalty: function(card) {
-      return card.suit === 'weather';
+      return card.suit === 'weather' || card.name === 'Phoenix';
     },
     relatedSuits: ['weather'],
     relatedCards: ['Dwarvish Infantry', 'Dragon']
@@ -80,7 +80,7 @@ var base = {
     bonusScore: function(hand) {
       var max = 0;
       for (const card of hand.nonBlankedCards()) {
-        if (card.suit === 'weapon' || card.suit === 'flood' || card.suit === 'flame' || card.suit === 'land' || card.suit === 'weather') {
+        if (card.suit === 'weapon' || card.suit === 'flood' || card.suit === 'flame' || card.suit === 'land' || card.suit === 'weather' || card.name === 'Phoenix') {
           if (card.strength > max) {
             max = card.strength;
           }
@@ -191,7 +191,7 @@ var base = {
     bonus: false,
     penalty: true,
     blankedIf: function(hand) {
-      return !hand.containsSuit('flame');
+      return !hand.containsSuit('flame') && !hand.containsId(PHOENIX, false);
     },
     relatedSuits: ['flame'],
     relatedCards: []
@@ -310,7 +310,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return hand.containsSuit('weather') ? 0 : 5;
+      return hand.containsSuit('weather') || hand.contains('Phoenix') ? 0 : 5;
     },
     relatedSuits: ['weather'],
     relatedCards: []
@@ -438,7 +438,7 @@ var base = {
     bonus: true,
     penalty: false,
     bonusScore: function(hand) {
-      return 5 * (hand.countSuit('land') + hand.countSuit('weather') + hand.countSuit('flood') + hand.countSuit('flame'));
+      return 5 * (hand.countSuit('land') + hand.countSuit('weather') + hand.countSuit('flood') + hand.countSuit('flame') + hand.countCardName('Phoenix'));
     },
     relatedSuits: ['land', 'weather', 'flood', 'flame'],
     relatedCards: []
@@ -644,7 +644,7 @@ var base = {
     bonus: false,
     penalty: true,
     blankedIf: function(hand) {
-      return (!hand.containsSuit('army') && !isArmyClearedFromPenalty(this, hand)) || hand.containsSuit('weather');
+      return (!hand.containsSuit('army') && !isArmyClearedFromPenalty(this, hand)) || hand.containsSuitExcluding('weather', PHOENIX);
     },
     relatedSuits: ['army', 'weather'],
     relatedCards: []
@@ -802,7 +802,20 @@ var base = {
     },
     relatedSuits: [],
     relatedCards: []
-  }
+  },
+  'FR55': {
+    id: 'FR55',
+    suit: 'beast',
+    name: 'Phoenix',
+    strength: 14,
+    bonus: false,
+    penalty: true,
+    blankedIf: function(hand) {
+      return hand.containsSuit('flood');
+    },
+    relatedSuits: ['weather', 'flood', 'flame'].sort(),
+    relatedCards: []
+  },
 };
 
 var cursedHoard = {
@@ -959,7 +972,7 @@ var cursedHoard = {
     bonus: false,
     penalty: true,
     blanks: function(card, hand) {
-      return card.suit !== 'outsider' && hand.countSuit(card.suit) === 1;
+      return card.suit !== 'outsider' && hand.countSuit(card.suit) === 1 && card.id !== PHOENIX;
     },
     relatedSuits: ['outsider'],
     relatedCards: []
@@ -1059,7 +1072,7 @@ var cursedHoard = {
     bonusScore: function(hand) {
       var max = 0;
       for (const card of hand.nonBlankedCards()) {
-        if (card.suit === 'building' || card.suit === 'weapon' || card.suit === 'flood' || card.suit === 'flame' || card.suit === 'land' || card.suit === 'weather') {
+        if (card.suit === 'building' || card.suit === 'weapon' || card.suit === 'flood' || card.suit === 'flame' || card.suit === 'land' || card.suit === 'weather' || card.id === PHOENIX) {
           if (card.strength > max) {
             max = card.strength;
           }
@@ -1481,6 +1494,7 @@ var BOOK_OF_CHANGES = 'FR49';
 var SHAPESHIFTER = 'FR51';
 var MIRAGE = 'FR52';
 var DOPPELGANGER = 'FR53';
+var PHOENIX = 'FR55';
 
 var CH_NECROMANCER = 'CH20';
 var CH_SHAPESHIFTER = 'CH22';

--- a/js/find-scores.js
+++ b/js/find-scores.js
@@ -171,7 +171,7 @@ function generateActionVariations(hand) {
   if (hand.containsId(ISLAND)) {
     var islandActions = [];
     for (const card of hand.cards()) {
-      if (((card.suit === 'Flood' || card.suit === 'Flame' || hand.containsId(BOOK_OF_CHANGES)) && card.penalty) || card.id === DOPPELGANGER) {
+      if (((card.suit === 'Flood' || card.suit === 'Flame' || card.id === PHOENIX || hand.containsId(BOOK_OF_CHANGES)) && card.penalty) || card.id === DOPPELGANGER) {
         islandActions.push([ISLAND, + card.id]);
       }
     }

--- a/js/hand.js
+++ b/js/hand.js
@@ -223,19 +223,13 @@ class Hand {
     for (const card of blanked) {
       card.blanked = true;
     }
-    let cardBlanked = false;
-    do {
-      cardBlanked = false;
-      for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
-        if (card.blankedIf !== undefined && !card.penaltyCleared) {
-          if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
-            card.blanked = true;
-            cardBlanked = true;
-          }
+    for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
+      if (card.blankedIf !== undefined && !card.penaltyCleared) {
+        if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
+          card.blanked = true;
         }
       }
-    } while (cardBlanked);
-
+    }
   }
 
   // a card that is blanked by another card cannot blank other cards,

--- a/js/hand.js
+++ b/js/hand.js
@@ -409,7 +409,7 @@ class CardInHand {
         }
       } else if (this.id === ISLAND) {
         var selectedCard = hand.getCardById(this.actionData[0]);
-        if (selectedCard === undefined || !(selectedCard.suit === 'flood' || selectedCard.suit === 'flame')) {
+        if (selectedCard === undefined || !(selectedCard.suit === 'flood' || selectedCard.suit === 'flame' || selectedCard.id === PHOENIX)) {
           this.actionData = undefined;
         } else {
           this.clearsPenalty = function(card) {

--- a/js/hand.js
+++ b/js/hand.js
@@ -91,7 +91,7 @@ class Hand {
 
   containsSuit(suitName) {
     for (const card of this.nonBlankedCards()) {
-      if (card.suit === suitName) {
+      if (card.suit === suitName || (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame'))) {
         return true;
       }
     }
@@ -100,7 +100,7 @@ class Hand {
 
   containsSuitExcluding(suitName, excludingCardId) {
     for (const card of this.nonBlankedCards()) {
-      if (card.suit === suitName && card.id !== excludingCardId) {
+      if ((card.suit === suitName || (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame'))) && card.id !== excludingCardId) {
         return true;
       }
     }
@@ -110,20 +110,7 @@ class Hand {
   countSuit(suitName) {
     var count = 0;
     for (const card of this.nonBlankedCards()) {
-      if (card.suit === suitName) {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  countSuitWithPhoenix(suitName) {
-    var count = 0;
-    for (const card of this.nonBlankedCards()) {
-      if (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame')) {
-        count++;
-      }
-      if (card.suit === suitName) {
+      if (card.suit === suitName || (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame'))) {
         count++;
       }
     }
@@ -133,7 +120,7 @@ class Hand {
   countSuitExcluding(suitName, excludingCardId) {
     var count = 0;
     for (const card of this.nonBlankedCards()) {
-      if (card.suit === suitName && card.id !== excludingCardId) {
+      if ((card.suit === suitName || (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame'))) && card.id !== excludingCardId) {
         count++;
       }
     }

--- a/js/hand.js
+++ b/js/hand.js
@@ -117,6 +117,19 @@ class Hand {
     return count;
   }
 
+  countSuitWithPhoenix(suitName) {
+    var count = 0;
+    for (const card of this.nonBlankedCards()) {
+      if (card.id === PHOENIX && (suitName === 'weather' || suitName === 'flame')) {
+        count++;
+      }
+      if (card.suit === suitName) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   countSuitExcluding(suitName, excludingCardId) {
     var count = 0;
     for (const card of this.nonBlankedCards()) {
@@ -210,13 +223,19 @@ class Hand {
     for (const card of blanked) {
       card.blanked = true;
     }
-    for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
-      if (card.blankedIf !== undefined && !card.penaltyCleared) {
-        if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
-          card.blanked = true;
+    let cardBlanked = false;
+    do {
+      cardBlanked = false;
+      for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
+        if (card.blankedIf !== undefined && !card.penaltyCleared) {
+          if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
+            card.blanked = true;
+            cardBlanked = true;
+          }
         }
       }
-    }
+    } while (cardBlanked);
+
   }
 
   // a card that is blanked by another card cannot blank other cards,

--- a/js/tests.js
+++ b/js/tests.js
@@ -43,6 +43,8 @@ $(document).ready(function() {
   assertScoreByCode('FR55,FR02,CH17,FR15,FR22,FR26,FR11+', 114, 'Phoenix also counts as a Weather');
   assertScoreByCode('FR55,FR13,FR20,FR17,FR26+', 94, 'Phoenix also counts as a Flame');
   assertScoreByCode('FR55,FR20,FR17,FR26,FR19,FR15,FR14,FR13+', 252, 'Phoenix is a Flame and a Weather at the same time');
+  assertScoreByCode('FR55,FR30+', 29, 'Phoenix gives double bonus for Enchantress');
+  assertScoreByCode('FR55,FR12+', 34, 'Phoenix gives double penalty for Blizzard');
   assertScoreByCode('FR55,CH21,FR15+', 35, 'Bonus of Phoenix prevents bonus of World Tree');
   assertScoreByCode('FR55,FR20,FR15,CH22,FR53,FR26,FR27+CH22:FR55,FR53:FR55', 109, 'Copy of a Phoenix only counts as a Beast');
 });

--- a/js/tests.js
+++ b/js/tests.js
@@ -26,14 +26,25 @@ $(document).ready(function() {
   assertScoreByCode('FR49,FR41,FR37,FR21+FR49:FR37:flood', 73, 'Blanking III');
   assertScoreByCode('FR49,FR41,FR24,FR22+FR49:FR24:flood', 56, 'Blanking IV');
   assertScoreByCode('FR49,FR41,FR06,FR08,FR22+FR49:FR08:wizard', 82, 'Blanking V');
-  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 47, 'Bug?');
+  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 24, 'War Dirigible and Warship are blanked');
   assertScoreByCode('FR49,FR41,FR45+FR49:FR45:flood', 61, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR49,FR45,FR25+FR49:FR25:land', 53, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR21,FR45,FR13+', 47, 'War Dirigible + Smoke');
   assertScoreByCode('FR21,FR13,FR45+', 47, 'Smoke + War Dirigible');
   deck.enableCursedHoardSuits();
+  cursedHoardSuits = true;
   assertScoreByCode('CH10,FR41,FR10,FR07,FR22,FR23+', 114);
   assertScoreByCode('CH08,FR32,FR37+CH08:FR32', 57, 'Angel');
+  assertScoreByCode('FR55,FR37,FR16,FR11,CH08,FR49+CH08:FR16,FR49:FR37:wizard', 116, 'Phoenix can not be blanked by any card except Floods');
+  assertScoreByCode('FR55,CH10+', 59, 'Phoenix can not be blanked by Demon');
+  assertScoreByCode('FR55,CH10,FR18,FR15+', 87, 'Phoenix prevents blanking by Demon because of its bonus');
+  assertScoreByCode('CH18,FR55,FR27+', 41, 'Great Flood can still blank a Phoenix since it is a Flood');
+  assertScoreByCode('FR55,FR45,FR22+', 59, 'Phoenix can not blank any other card');
+  assertScoreByCode('FR55,FR02,CH17,FR15,FR22,FR26,FR11+', 114, 'Phoenix also counts as a Weather');
+  assertScoreByCode('FR55,FR13,FR20,FR17,FR26+', 94, 'Phoenix also counts as a Flame');
+  assertScoreByCode('FR55,FR20,FR17,FR26,FR19,FR15,FR14,FR13+', 252, 'Phoenix is a Flame and a Weather at the same time');
+  assertScoreByCode('FR55,CH21,FR15+', 35, 'Bonus of Phoenix prevents bonus of World Tree');
+  assertScoreByCode('FR55,FR20,FR15,CH22,FR53,FR26,FR27+CH22:FR55,FR53:FR55', 109, 'Copy of a Phoenix only counts as a Beast');
 });
 
 function assertScoreByName(cardNames, expectedScore, message) {

--- a/js/tests.js
+++ b/js/tests.js
@@ -26,7 +26,7 @@ $(document).ready(function() {
   assertScoreByCode('FR49,FR41,FR37,FR21+FR49:FR37:flood', 73, 'Blanking III');
   assertScoreByCode('FR49,FR41,FR24,FR22+FR49:FR24:flood', 56, 'Blanking IV');
   assertScoreByCode('FR49,FR41,FR06,FR08,FR22+FR49:FR08:wizard', 82, 'Blanking V');
-  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 24, 'War Dirigible and Warship are blanked');
+  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 47, 'Bug?');
   assertScoreByCode('FR49,FR41,FR45+FR49:FR45:flood', 61, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR49,FR45,FR25+FR49:FR25:land', 53, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR21,FR45,FR13+', 47, 'War Dirigible + Smoke');


### PR DESCRIPTION
Hey, first of all thank you for creating this app, I really like it and don't play the game without it anymore:)!
In this PR, I've added the Deluxe Edition version of the Phoenix card and added some tests. 

I wasn't sure about one rule though. The card also counts as Flame and Weather through a BONUS. So whenever
it is in your hand and its not blanked (by a Flood) it has 3 suits (Beast, Flame and Weather). But how many suits does it
have when its in discard? For example, does Dark Queen get +5 when Phoenix is in discard? My implementation counts it only as a Beast whenever its in discard (so no +5 for Dark Queen) because my understanding is that the BONUS of a card only makes sense as long as it is in the hand of a player (which is the case for ALL other cards in the game). Besides they could have printed this card with triple colors instead of making it a BONUS, if they wanted for it to have triple suits when it is in discard, right? 
Following the same logic, I implemented it so that it can not be duplicated by a Mirage, since I count it only as a Beast when it is not in the hand of a player. What do you think about this approach in general?

I also count it only as a Beast whenever it is copied (by Shapeshifter and Doppelgänger) because these cards do not copy the BONUS of a card.

Apart from adding the card I made a small change in the blanking logic. There is a test case with the description "Bug?" (Warship, War Dirigible, Light Cavalry, Air Elemental, Book of Changes:War Dirigible -> Flood) and it think it was in fact a bug :) 
In this case we have two cards which have a blankedIf method; Warship and War Dirigible. When going over the cards and running their blankedIf methods, the blanking of these cards change depending on the order in which we run them. There are two possibilities:

1) Run blankedIf method of Warship first, then run War Dirigible
    In this case Warship is not blanked because the War Dirigible (which is a Flood) is not blanked yet. Then, War Dirigible becomes blank because of the Air Elemental --> Warship: NOT BLANKED, War Dirigible: BLANKED
2) Run blankedIf method of War Dirigible first, then run Warship
    In this case War Dirigible is blanked because of the Air Elemental, then Warship is also blanked because War Dirigible is blanked --> Warship: BLANKED, War Dirigible: BLANKED

I think the blanking should not depend on the order, thats why I implemented it so that it keeps going over the cards until no new card has been blanked.

Let me know if you find any issues!