### PR TITLE
Fix blankedIf call logic

### DIFF
--- a/js/hand.js
+++ b/js/hand.js
@@ -210,13 +210,18 @@ class Hand {
     for (const card of blanked) {
       card.blanked = true;
     }
-    for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
-      if (card.blankedIf !== undefined && !card.penaltyCleared) {
-        if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
-          card.blanked = true;
+    let cardBlanked = false;
+    do {
+      cardBlanked = false;
+      for (const card of this.nonBlankedCards().sort((a, b) => a.id.localeCompare(b.id))) {
+        if (card.blankedIf !== undefined && !card.penaltyCleared) {
+          if (card.blankedIf(this) && !this._cannotBeBlanked(card)) {
+            card.blanked = true;
+            cardBlanked = true;
+          }
         }
       }
-    }
+    } while (cardBlanked);
   }
 
   // a card that is blanked by another card cannot blank other cards,

--- a/js/tests.js
+++ b/js/tests.js
@@ -26,7 +26,7 @@ $(document).ready(function() {
   assertScoreByCode('FR49,FR41,FR37,FR21+FR49:FR37:flood', 73, 'Blanking III');
   assertScoreByCode('FR49,FR41,FR24,FR22+FR49:FR24:flood', 56, 'Blanking IV');
   assertScoreByCode('FR49,FR41,FR06,FR08,FR22+FR49:FR08:wizard', 82, 'Blanking V');
-  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 47, 'Bug?');
+  assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 24, 'War Dirigible and Warship are blanked');
   assertScoreByCode('FR49,FR41,FR45+FR49:FR45:flood', 61, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR49,FR45,FR25+FR49:FR25:land', 53, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR21,FR45,FR13+', 47, 'War Dirigible + Smoke');

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 var APP_PREFIX = 'fantasy-realms-';
-var VERSION = '1.0.33';
+var VERSION = '1.0.34';
 var CACHE_NAME = APP_PREFIX + VERSION;
 var URLS = [
   '/',


### PR DESCRIPTION
This PR fixes a use case in the blanking logic which is also contained in the "Bug?" test case (Warship, War Dirigible, Light Cavalry, Air Elemental, Book of Changes:War Dirigible -> Flood) 
In this case we have two cards which have a blankedIf method; Warship and War Dirigible. When going over the cards and running their blankedIf methods, the blanking of these cards change depending on the order in which we run them. There are two possibilities:

Run blankedIf method of Warship first, then run War Dirigible
In this case Warship is not blanked because the War Dirigible (which is a Flood) is not blanked yet. Then, War Dirigible becomes blank because of the Air Elemental --> Warship: NOT BLANKED, War Dirigible: BLANKED
Run blankedIf method of War Dirigible first, then run Warship
In this case War Dirigible is blanked because of the Air Elemental, then Warship is also blanked because War Dirigible is blanked --> Warship: BLANKED, War Dirigible: BLANKED

I think the blanking should not depend on the order, thats why I implemented it so that it keeps going over the cards until no new card has been blanked.