### PR TITLE
Fix infinite blank cycles

### DIFF
--- a/js/deck.js
+++ b/js/deck.js
@@ -1496,6 +1496,10 @@ var deck = {
     }
   },
   getCardById: function (id) {
+    if (typeof(id) == "number") {
+      id = id.toString()
+    }
+
     if (id.match(/^[0-9+]+$/)) {
       id = 'FR' + id.padStart(2, '0')
     }

--- a/js/tests.js
+++ b/js/tests.js
@@ -27,6 +27,10 @@ $(document).ready(function () {
   assertScoreByCode('FR49,FR41,FR37,FR21+FR49:FR37:flood', 73, 'Blanking III');
   assertScoreByCode('FR49,FR41,FR24,FR22+FR49:FR24:flood', 56, 'Blanking IV');
   assertScoreByCode('FR49,FR41,FR06,FR08,FR22+FR49:FR08:wizard', 82, 'Blanking V');
+  assertScoreByCode('FR08,FR12,FR16+', 65, 'Blanking cycle (base case) - Rulebook Q&A'); // Blizzard: 30 - 5  + Wildfire: 40 = 65
+  assertScoreByCode('FR02,FR08,FR12,FR16+', 62, 'Blanking cycle (with cavern) - Rulebook Q&A'); // Blizzard: 30 + Flood: 32 = 62
+  assertScoreByCode('FR08,FR12,FR16,FR49+FR49:FR12:beast', 3, 'Blanking cycle (with book changing Blizzard to beast)'); // Assuming cycle blanks itself, only book is active
+  assertScoreByCode('FR02,FR08,FR12,FR16,FR49+FR49:FR12:beast', 9, 'Blanking cycle (with cavern and book)'); // Cycle blanks itself. Cavern isn't blanked : 6 + book 3 = 9
   assertScoreByCode('FR49,FR41,FR45,FR23,FR15+FR49:FR45:flood', 24, 'War Dirigible and Warship are blanked');
   assertScoreByCode('FR49,FR41,FR45+FR49:FR45:flood', 61, 'War Dirigible does not need Army when Army cleared from penalty');
   assertScoreByCode('FR49,FR45,FR25+FR49:FR25:land', 53, 'War Dirigible does not need Army when Army cleared from penalty');


### PR DESCRIPTION
## Summary
This PR fixes an infinite recursion in hand score and a few other miscellaneous issues in the optimization script

## Infinite recursion
The main proposal of this PR is to fix a nasty bug in scoring the following hand:
- **_Great Flood_**
- **_Blizzard_**
- **_Wildfire_**
- **_Book of Changes_** (Changing _Blizzard_ to e.g Beast)
- **_Forest_**(or any land)

In this case, there is a 3-cycle of blanking cards : 
- _Great Flood_ is blanked by _Blizzard_ (blanks all floods)
- _Blizzard_(modified suit to Beast) is blanked by _Wildfire_ (since it isn't a weather anymore)
- _Wildfire_ is blanked by _Great Flood_ (blank all flames except _Lightning_)

The current code scores the [hand of 4](https://fantasy-realms.github.io/index.html?hand=FR08,FR12,FR16,FR49+FR49:FR12:beast) (without the _Forest_) by blanking all three cards in the cycle simultaneously, leaving only the _Book of Changes_ active. (See issue #37) This is consistent with the "Two Basilisks" rule of cards blanking each other in the rules Q&A. 

However, the script fails if you add another Land to the hand (for example a _Forest_).  If you run [this hand](https://fantasy-realms.github.io/index.html?hand=FR04,FR08,FR12,FR16,FR49+FR49:FR12:beast) on the website it will crash with a "too much recursion" error.

The problem is in the `_cardBlanked()` method which will go in a infinite recursion when trying to determine if the _Forest_ is blanked or not:.
There is a piece of code responsible for breaking the cycle by checking if `by === target`, but in this case it doesn't get triggered if the starting card (`target`, i.e. _Forest_) does not belong to the cycle.

I changed the method to maintain a list of traversed cards, which allows to break out of any cycle.

This has the consequence of making a ruling (not explicitly stated in the rules booklet) : in this case **the _Forest_ is counted as active**, as it cannot be blanked by the Flood (since the 3-cycle is entirely blanked).

## Other fixes
I fixed a few issues  in of `find-scores` and `_cardBlanked`
-  a `try catch` block around the scoring (to avoid blocking the page on an infinite recursion)
- a conversion to string in the `normalizeID` to accept integer arguments

I rewrote `_cardBlanked` during my investigation to understand better how it worked. However the logic should be exactly the same except for the bugfix mentioned above.

## Tests
I added a few unit tests around this new edge case.

