### PR TITLE
Add outsider to Wildfire non-blanks

### DIFF
--- a/doc/blanking-and-clearing.txt
+++ b/doc/blanking-and-clearing.txt
@@ -19,7 +19,7 @@ WEATHER:
 	
 FLAME:
 
-	Wildfire: BLANKS all cards except Flames, Wizards, Weather, Weapons, Artifacts, Mountain, Great Flood, Island, Unicorn and Dragon.
+	Wildfire: BLANKS all cards except Flames, Wizards, Weather, Weapons, Artifacts, Outsiders, Mountain, Great Flood, Island, Unicorn and Dragon.
 	--> blanks Basilisk
 	--> blanks Cavern, but Cavern first clears penalty on all weather
 	--> blanks Rangers, but Rangers firs clear word Army from all penalties 

--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -58,7 +58,7 @@ FR14.bonus=+40 with <span class="weather">Rainstorm</span> and either <span clas
 FR15.name=Air Elemental
 FR15.bonus=+15 for each other <span class="weather">Weather</span>.
 FR16.name=Wildfire
-FR16.penalty=BLANKS all cards except <span class="flame">Flames</span>, <span class="wizard">Wizards</span>, <span class="weather">Weather</span>, <span class="weapon">Weapons</span>, <span class="artifact">Artifacts</span>, <span class="land">Mountain</span>, <span class="flood">Great Flood</span>, <span class="flood">Island</span>, <span class="beast">Unicorn</span> and <span class="beast">Dragon</span>.
+FR16.penalty=BLANKS all cards except <span class="flame">Flames</span>, <span class="wizard">Wizards</span>, <span class="weather">Weather</span>, <span class="weapon">Weapons</span>, <span class="artifact">Artifacts</span>, <span class="outsider">Outsiders</span>, <span class="land">Mountain</span>, <span class="flood">Great Flood</span>, <span class="flood">Island</span>, <span class="beast">Unicorn</span> and <span class="beast">Dragon</span>.
 FR17.name=Candle
 FR17.bonus=+100 with <span class="artifact">Book of Changes</span>, <span class="land">Bell Tower</span>, and any one <span class="wizard">Wizard</span>.
 FR18.name=Forge

--- a/i18n/Messages_en.properties
+++ b/i18n/Messages_en.properties
@@ -58,7 +58,7 @@ FR14.bonus=+40 with <span class="weather">Rainstorm</span> and either <span clas
 FR15.name=Air Elemental
 FR15.bonus=+15 for each other <span class="weather">Weather</span>.
 FR16.name=Wildfire
-FR16.penalty=BLANKS all cards except <span class="flame">Flames</span>, <span class="wizard">Wizards</span>, <span class="weather">Weather</span>, <span class="weapon">Weapons</span>, <span class="artifact">Artifacts</span>, <span class="land">Mountain</span>, <span class="flood">Great Flood</span>, <span class="flood">Island</span>, <span class="beast">Unicorn</span> and <span class="beast">Dragon</span>.
+FR16.penalty=BLANKS all cards except <span class="flame">Flames</span>, <span class="wizard">Wizards</span>, <span class="weather">Weather</span>, <span class="weapon">Weapons</span>, <span class="artifact">Artifacts</span>, <span class="outsider">Outsiders</span>, <span class="land">Mountain</span>, <span class="flood">Great Flood</span>, <span class="flood">Island</span>, <span class="beast">Unicorn</span> and <span class="beast">Dragon</span>.
 FR17.name=Candle
 FR17.bonus=+100 with <span class="artifact">Book of Changes</span>, <span class="land">Bell Tower</span>, and any one <span class="wizard">Wizard</span>.
 FR18.name=Forge

--- a/js/deck.js
+++ b/js/deck.js
@@ -231,8 +231,9 @@ var base = {
     penalty: true,
     blanks: function (card, hand) {
       return !(card.suit === 'flame' || card.suit === 'wizard' || card.suit === 'weather' ||
-        card.suit === 'weapon' || card.suit === 'artifact' || card.suit === 'wild' || card.name === 'Mountain' ||
-        card.name === 'Great Flood' || card.name === 'Island' || card.name === 'Unicorn' || card.name === 'Dragon' ||
+               card.suit === 'weapon' || card.suit === 'artifact' || card.suit === 'wild' || card.suit === 'outsider' ||
+               card.name === 'Mountain' || card.name === 'Great Flood' || card.name === 'Island' ||
+               card.name === 'Unicorn' || card.name === 'Dragon' ||
         isPhoenix(card));
     },
     relatedSuits: allSuits(),


### PR DESCRIPTION
Noticed that Outsiders was not included in the list of non-blanked cards for Wildfire. Adds Outsiders to the non-blank logic.